### PR TITLE
CMake: libname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,11 @@ set(SOURCES
 
 # library
 add_library(MPILander ${SOURCES} ${HEADERS})
-# add_library(MPILander::MPILander ALIAS MPILander)
+add_library(MPILander::MPILander ALIAS MPILander)
 
 # properties
+set_target_properties(MPILander PROPERTIES OUTPUT_NAME "mpi")
+
 target_compile_features(MPILander
     PUBLIC cxx_std_11
 )


### PR DESCRIPTION
Add proper library name and namespace alias for direct inclusion.

Follow-up to #7